### PR TITLE
Reserve slash in slug_case

### DIFF
--- a/oboe/utils.py
+++ b/oboe/utils.py
@@ -10,7 +10,7 @@ def slug_case(text):
     import unicodedata
     text = str(text)
     text = unicodedata.normalize('NFKC', text)
-    text = re.sub(r'[^\w\s-]', '', text.lower())
+    text = re.sub(r'[^/\w\s-]', '', text.lower())
     return re.sub(r'[-\s]+', '-', text).strip('-_')
 
 


### PR DESCRIPTION
Keep slash in `slug_case` so that paths with subfolders can be generated correctly.